### PR TITLE
Added battery level indication

### DIFF
--- a/lib/Display/Display.cpp
+++ b/lib/Display/Display.cpp
@@ -43,10 +43,13 @@ void Display::set_main_menu_screen(int delay, String status)
     buffer.setTextSize(1);
     buffer.drawString(address, 120 - (buffer.textWidth(address)/2.0), 5);
     buffer.drawLine(0, 28, 240, 28, (negatif?TFT_WHITE:TFT_BLACK));
+    buffer.drawString("Interval (s):", 30, 35);
     buffer.drawString(status, 120 - (buffer.textWidth(status)/2.0), 112);
     buffer.drawLine(0, 107, 240, 107, (negatif?TFT_WHITE:TFT_BLACK));
 
-    buffer.drawString("Interval (secs):", 30, 35);
+    buffer.setFreeFont(font_text_small);
+    buffer.drawString("Batt%:",190,73);
+    buffer.drawFloat(((M5.Axp.GetBatVoltage()-3.27)/(4.2-3.27))*100,1,200,88); // Battery: 120 mAh @ 3.7V (444 mWh), 3.27-4.2V accepted range
     buffer.setFreeFont(font_titles);
     buffer.drawFloat(float(delay)/1000.0, 1, 30, 60);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,6 +12,7 @@
 String name_remote = "BR-M5";
 CanonBLERemote canon_ble(name_remote);
 Display M5_display(&M5.Lcd, name_remote);
+String status = "init";
 
 TimeLapse timelapse(400);
 
@@ -49,7 +50,8 @@ void setup()
     Serial.println("Setup Done");
     
     M5_display.set_address(canon_ble.getPairedAddressString());
-    M5_display.set_main_menu_screen(timelapse.get_interval(), "Ready for single shot");
+    status = "Ready for single shot";
+    M5_display.set_main_menu_screen(timelapse.get_interval(), status);
 }
 
 
@@ -83,12 +85,14 @@ void update_shooting()
             if (timelapse.Recording_OnOFF())
             {
                 Serial.println("Start timelapse");
-                M5_display.set_main_menu_screen(timelapse.get_interval(), "Shooting timelapse");
+                status = "Shooting timelapse";
+                M5_display.set_main_menu_screen(timelapse.get_interval(), status);
             }
             else
             {
                 Serial.println("Stop timelapse");
-                M5_display.set_main_menu_screen(timelapse.get_interval(), "Ready for timelapse");
+                status = "Ready for timelapse";
+                M5_display.set_main_menu_screen(timelapse.get_interval(), status);
             }
         }
     }
@@ -99,12 +103,14 @@ void update_settings()
     if (M5.BtnA.wasReleased())
     {
         timelapse.TimeLapse_decDelay();
-        M5_display.set_main_menu_screen(timelapse.get_interval(), "Setting interval");
+        status = "Setting interval";
+        M5_display.set_main_menu_screen(timelapse.get_interval(), status);
     }
     if (M5.BtnB.wasReleased())
     {
         timelapse.TimeLapse_incDelay();
-        M5_display.set_main_menu_screen(timelapse.get_interval(), "Setting interval");
+        status = "Setting interval";
+        M5_display.set_main_menu_screen(timelapse.get_interval(), status);
     }
 }
 
@@ -120,8 +126,7 @@ void loop()
         {
             // M5.BtnB.reset();
             current_mode = Shooting;
-            String status = (timelapse.get_interval()==0)?"Ready for single shot":"Ready for timelapse";
-            M5_display.set_main_menu_screen(timelapse.get_interval(), status);
+            status = (timelapse.get_interval()==0)?"Ready for single shot":"Ready for timelapse";
         }
         else
         {
@@ -134,7 +139,7 @@ void loop()
         {
             // M5.BtnB.reset();
             current_mode = Settings;
-            M5_display.set_main_menu_screen(timelapse.get_interval(), "Setting interval");
+            status = "Setting interval";
         }
         else
         {
@@ -145,5 +150,7 @@ void loop()
     default:
         break;
     }
+
+    M5_display.set_main_menu_screen(timelapse.get_interval(), status);
     delay(10);
 }


### PR DESCRIPTION
I added a (rough) battery level indication. The calculation is based on battery voltage levels for the MStickC I found online and could be improved with real-world data. The placement is convenient, but if one would use very long time intervals, it could overlap. Still, better than no indication!
I had to move the display update call out of the switch-case to constantly update the levels and had to add some more lines in the other functions as a consequence of that.